### PR TITLE
Update atomsbonds.i.md

### DIFF
--- a/atomsbonds.i.md
+++ b/atomsbonds.i.md
@@ -18,8 +18,15 @@ formal charge is currently unknown.
 
 The CDK interface `IAtom` is the underlying data model of atoms. Creating
 a new atom is fairly easy. For example, we can create an atom of element
-type carbon, as defined by the element’s symbol that we pass as parameter
+type carbon, as defined by the element’s atomic number that we pass as parameter
 in the constructor:
+
+```
+new Atom(6); // 6=Carbon
+```
+
+An atom can also be constructed by passing in the symbol but this is marginally
+less efficient:
 
 <code>CreateAtom1</code>
 
@@ -32,8 +39,7 @@ A CDK atom has many properties, many of them inherited from the `IElement`,
 `IIsotope` and `IAtomType` interfaces. Figure 3.1 shows the interface
 inheritance specified by the CDK data model.
 
-These constructors will set both the symbol as well as the atomic number
-of the atom:
+These constructors will set the atomic number of the atom:
 
 <out>CreateAtom2</out>
 


### PR DESCRIPTION
Saw it on the blog and thought it should be updated. Atom's (or actually elements) only store the atomic number and not the symbol. It's this way because the symbol can be derived from a direct int -> string lookup (efficient), the reverse string -> int is less efficient.

Either way the ""**best**"" way to create atoms is with the atomic number (the Enum isn't terrible).